### PR TITLE
Try to fix crash due to extremely bad load balancing in parallel_match()

### DIFF
--- a/python/virgo/mpi/parallel_sort.py
+++ b/python/virgo/mpi/parallel_sort.py
@@ -872,7 +872,8 @@ def parallel_match(arr1, arr2, arr2_sorted=False, comm=None):
         sendrecv(dest, arr1_sendbuf, arr1_recvbuf, comm=comm)
 
         # Match received arr1 values against local arr2 and look up indexes of matches
-        ptr = virgo.util.match.match(arr1_recvbuf, arr2_ordered, arr2_sorted=True)        
+        ptr = virgo.util.match.match(arr1_recvbuf, arr2_ordered, arr2_sorted=True)
+        del arr1_recvbuf
         index_sendbuf = -np.ones(ptr.shape, dtype=index_dtype)
         index_sendbuf[ptr>=0] = index_in[ptr[ptr>=0]]
 
@@ -880,7 +881,8 @@ def parallel_match(arr1, arr2, arr2_sorted=False, comm=None):
         # a request.
         index_recvbuf = index_local if send_arr1 else index_local[:0]
         sendrecv(dest, index_sendbuf, index_recvbuf, comm=comm)
-
+        del index_sendbuf
+        
         #
         # If the local arr1 section is larger than the remote arr2 then we'll
         # import the remote arr2 and corresponding indexes and do the matching
@@ -903,8 +905,10 @@ def parallel_match(arr1, arr2, arr2_sorted=False, comm=None):
         sendrecv(dest, index_sendbuf, index_recvbuf, comm=comm)
 
         # We can now check if the imported arr2 values match our local arr1 section
-        ptr = virgo.util.match.match(arr1_local, arr2_recvbuf, arr2_sorted=True)        
+        ptr = virgo.util.match.match(arr1_local, arr2_recvbuf, arr2_sorted=True)
+        del arr2_recvbuf
         index_local[ptr>=0] = index_recvbuf[ptr[ptr>=0]]
+        del index_recvbuf
         
     # Restore original order
     index = np.empty_like(index_out)

--- a/python/virgo/mpi/parallel_sort.py
+++ b/python/virgo/mpi/parallel_sort.py
@@ -820,6 +820,9 @@ def parallel_match(arr1, arr2, arr2_sorted=False, comm=None):
     recv_count = np.ndarray(comm_size, dtype=index_dtype)
     comm.Alltoall(send_count, recv_count)
 
+    # Allocate array for the result
+    index_out = np.zeros(arr1.shape, dtype=index_dtype) - 1
+
     #
     # Loop over MPI ranks to communicate with
     #
@@ -836,7 +839,7 @@ def parallel_match(arr1, arr2, arr2_sorted=False, comm=None):
         sendrecv(dest, arr1_send, arr1_recv, comm=comm)
 
         # For each imported arr1 element, find global rank of the matching arr2 element
-        ptr = virgo.util.match(arr1_recv, arr2_ordered, arr2_sorted=True)        
+        ptr = virgo.util.match.match(arr1_recv, arr2_ordered, arr2_sorted=True)        
         del arr1_recv
         index_return = -np.ones(ptr.shape, dtype=index_dtype)
         index_return[ptr>=0] = index_in[ptr[ptr>=0]]

--- a/python/virgo/mpi/parallel_sort.py
+++ b/python/virgo/mpi/parallel_sort.py
@@ -96,6 +96,54 @@ def my_argsort(arr):
     return np.argsort(arr, kind='mergesort')
 
 
+def sendrecv(dest, sendbuf, recvbuf, comm=None, nchunk=None):
+    """
+    Sendrecv implementation which splits communications where necessary.
+    Source and destination are assumed to be the same. Arrays must be 1D.
+    
+    dest    - other MPI rank to communicate with
+    sendbuf - array to send
+    recvbuf - array to receive into
+    comm    - communicator to use, defaults to MPI_COMM_WORLD
+    nchunk  - maximum number of elements per send (default 100MB)
+    """
+
+    # Get communicator to use
+    from mpi4py import MPI
+    if comm is None:
+        comm = MPI.COMM_WORLD
+    comm_rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+    
+    # Get data types
+    mpi_type_send = mpi_datatype(sendbuf.dtype)
+    mpi_type_recv = mpi_datatype(recvbuf.dtype)
+    
+    # Maximum number of elements per message: avoid messages > 2GB
+    assert sendbuf.dtype == recvbuf.dtype
+    assert len(sendbuf.shape) == 1
+    assert len(recvbuf.shape) == 1
+    if nchunk is None:
+        nchunk = (100*1024*1024) // sendbuf.dtype.itemsize
+    
+    # Determine number of elements to send and receive
+    nr_send_left = sendbuf.shape[0]
+    nr_recv_left = comm.sendrecv(nr_send_left, dest=dest, source=dest)
+
+    # Transfer data until it has all been moved
+    send_offset = 0
+    recv_offset = 0
+    while (nr_send_left > 0) or (nr_recv_left > 0):
+        nr_send = min(nchunk, nr_send_left)
+        nr_recv = min(nchunk, nr_recv_left)
+        comm.Sendrecv(sendbuf[send_offset:send_offset+nr_send], dest,
+                      recvbuf=recvbuf[recv_offset:recv_offset+nr_recv],
+                      source=dest)
+        send_offset  += nr_send
+        nr_send_left -= nr_send
+        recv_offset  += nr_recv
+        nr_recv_left -= nr_recv
+    
 
 def repartition(arr, ndesired, comm=None):
     """Return the input arr repartitioned between processors"""

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -6,6 +6,13 @@ import h5py
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 
+# Ensure a different random seed on each MPI rank
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+np.random.seed(comm_rank)
+
+
 def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     """
     Write out a dataset in serial mode, read it back in collective mode

--- a/python/virgo/mpi/test_parallel_sort.py
+++ b/python/virgo/mpi/test_parallel_sort.py
@@ -5,6 +5,13 @@ import numpy as np
 import pytest
 import virgo.mpi.parallel_sort as psort
 
+# Ensure a different random seed on each MPI rank
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+np.random.seed(comm_rank)
+
+
 def assert_all_ranks(condition, message, comm=None):
     """Fails assertion on all ranks if condition is False on any rank"""
     from mpi4py import MPI

--- a/python/virgo/mpi/test_parallel_sort.py
+++ b/python/virgo/mpi/test_parallel_sort.py
@@ -519,9 +519,8 @@ def run_parallel_match(min_nr_per_rank, max_nr_per_rank, frac_arr1, frac_arr2):
         ptr = psort.parallel_match(arr1, arr2, comm=comm)
         verify_parallel_match(arr1, arr2, ptr, comm=comm)
 
-        ptr = psort.parallel_hash_match(arr1, arr2, comm=comm)
+        ptr = psort.HashMatcher(arr2, comm=comm).match(arr1)
         verify_parallel_match(arr1, arr2, ptr, comm=comm)
-
 
 @pytest.mark.mpi
 def test_parallel_match():

--- a/python/virgo/mpi/test_parallel_sort.py
+++ b/python/virgo/mpi/test_parallel_sort.py
@@ -519,7 +519,7 @@ def run_parallel_match(min_nr_per_rank, max_nr_per_rank, frac_arr1, frac_arr2):
         ptr = psort.parallel_match(arr1, arr2, comm=comm)
         verify_parallel_match(arr1, arr2, ptr, comm=comm)
 
-        ptr = psort.hash_match(arr1, arr2, comm=comm)
+        ptr = psort.parallel_hash_match(arr1, arr2, comm=comm)
         verify_parallel_match(arr1, arr2, ptr, comm=comm)
 
 

--- a/python/virgo/mpi/test_parallel_sort.py
+++ b/python/virgo/mpi/test_parallel_sort.py
@@ -519,6 +519,9 @@ def run_parallel_match(min_nr_per_rank, max_nr_per_rank, frac_arr1, frac_arr2):
         ptr = psort.parallel_match(arr1, arr2, comm=comm)
         verify_parallel_match(arr1, arr2, ptr, comm=comm)
 
+        ptr = psort.hash_match(arr1, arr2, comm=comm)
+        verify_parallel_match(arr1, arr2, ptr, comm=comm)
+
 
 @pytest.mark.mpi
 def test_parallel_match():

--- a/python/virgo/util/match.py
+++ b/python/virgo/util/match.py
@@ -16,6 +16,10 @@ def match(arr1, arr2, arr2_sorted=False, arr2_index=None):
     It is assumed that each element in arr1 only occurs once in arr2.
     """
 
+    # Check for the case where we're searching an empty arr2 - can't be any matches
+    if len(arr2) == 0:
+        return -ones(len(arr1), dtype=int)
+    
     # Workaround for a numpy bug (<=1.4): ensure arrays are native endian
     # because searchsorted ignores endian flag
     if not(arr1.dtype.isnative):


### PR DESCRIPTION
This branch attempts to prevent parallel_match from importing all of the data onto one MPI rank for some distributions of input values.

I've modified it so that each MPI rank communicates with one other rank at a time. This should save memory since we're not importing from all ranks simultaneously and it will also allow using a different strategy depending on how many array elements exist on each rank. We can either send our local elements to the remote rank and have it check for matches, or we can receive all elements from the remote rank and search them locally.

I've also added some unit tests for parallel_match() since there weren't any.