### PR TITLE
Add unit tests for parallel_match()

### DIFF
--- a/python/virgo/mpi/parallel_sort.py
+++ b/python/virgo/mpi/parallel_sort.py
@@ -143,8 +143,11 @@ def sendrecv(dest, sendbuf, recvbuf, comm=None, nchunk=None):
         nr_send_left -= nr_send
         recv_offset  += nr_recv
         nr_recv_left -= nr_recv
-    
 
+    mpi_type_send.Free()
+    mpi_type_recv.Free()
+
+        
 def repartition(arr, ndesired, comm=None):
     """Return the input arr repartitioned between processors"""
 

--- a/python/virgo/mpi/parallel_sort.py
+++ b/python/virgo/mpi/parallel_sort.py
@@ -96,6 +96,54 @@ def my_argsort(arr):
     return np.argsort(arr, kind='mergesort')
 
 
+def sendrecv(dest, sendbuf, recvbuf, comm=None, nchunk=None):
+    """
+    Sendrecv implementation which splits communications where necessary.
+    Source and destination are assumed to be the same. Arrays must be 1D.
+    
+    dest    - other MPI rank to communicate with
+    sendbuf - array to send
+    recvbuf - array to receive into
+    comm    - communicator to use, defaults to MPI_COMM_WORLD
+    nchunk  - maximum number of elements per send (default 100MB)
+    """
+
+    # Get communicator to use
+    from mpi4py import MPI
+    if comm is None:
+        comm = MPI.COMM_WORLD
+    comm_rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+    
+    # Get data types
+    mpi_type_send = mpi_datatype(sendbuf.dtype)
+    mpi_type_recv = mpi_datatype(recvbuf.dtype)
+    
+    # Maximum number of elements per message: avoid messages > 2GB
+    assert sendbuf.dtype == recvbuf.dtype
+    assert len(sendbuf.shape) == 1
+    assert len(recvbuf.shape) == 1
+    if nchunk is None:
+        nchunk = (100*1024*1024) // sendbuf.dtype.itemsize
+    
+    # Determine number of elements to send and receive
+    nr_send_left = sendbuf.shape[0]
+    nr_recv_left = comm.sendrecv(nr_send_left, dest=dest, source=dest)
+
+    # Transfer data until it has all been moved
+    send_offset = 0
+    recv_offset = 0
+    while (nr_send_left > 0) or (nr_recv_left > 0):
+        nr_send = min(nchunk, nr_send_left)
+        nr_recv = min(nchunk, nr_recv_left)
+        comm.Sendrecv(sendbuf[send_offset:send_offset+nr_send], dest,
+                      recvbuf=recvbuf[recv_offset:recv_offset+nr_recv],
+                      source=dest)
+        send_offset  += nr_send
+        nr_send_left -= nr_send
+        recv_offset  += nr_recv
+        nr_recv_left -= nr_recv
+    
 
 def repartition(arr, ndesired, comm=None):
     """Return the input arr repartitioned between processors"""

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -6,6 +6,13 @@ import h5py
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 
+# Ensure a different random seed on each MPI rank
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+np.random.seed(comm_rank)
+
+
 def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     """
     Write out a dataset in serial mode, read it back in collective mode

--- a/python/virgo/mpi/test_parallel_sort.py
+++ b/python/virgo/mpi/test_parallel_sort.py
@@ -5,6 +5,13 @@ import numpy as np
 import pytest
 import virgo.mpi.parallel_sort as psort
 
+# Ensure a different random seed on each MPI rank
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+np.random.seed(comm_rank)
+
+
 def assert_all_ranks(condition, message, comm=None):
     """Fails assertion on all ranks if condition is False on any rank"""
     from mpi4py import MPI

--- a/python/virgo/util/match.py
+++ b/python/virgo/util/match.py
@@ -16,6 +16,10 @@ def match(arr1, arr2, arr2_sorted=False, arr2_index=None):
     It is assumed that each element in arr1 only occurs once in arr2.
     """
 
+    # Check for the case where we're searching an empty arr2 - can't be any matches
+    if len(arr2) == 0:
+        return -ones(len(arr1), dtype=int)
+    
     # Workaround for a numpy bug (<=1.4): ensure arrays are native endian
     # because searchsorted ignores endian flag
     if not(arr1.dtype.isnative):


### PR DESCRIPTION
This adds the new unit tests and sendrecv function from #2 but drops the other changes that caused worse performance.