### PR TITLE
Update reading of attributes

### DIFF
--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -335,10 +335,10 @@ class MultiFile:
                     with h5py.File(filename, "r") as infile:
                         if file_nr_attr is not None:
                             obj, attr = file_nr_attr
-                            nr_files = int(infile[obj].attrs[attr])
+                            nr_files = int(infile[obj].attrs[attr].flat[0])
                             file_idx = np.arange(nr_files)
                         elif file_nr_dataset is not None:
-                            nr_files = int(infile[file_nr_dataset][...])
+                            nr_files = int(infile[file_nr_dataset][0])
                             file_idx = np.arange(nr_files)
                         else:
                             raise Exception("Must specify one of file_nr_attr, file_nr_dataset, file_idx")

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -335,10 +335,10 @@ class MultiFile:
                     with h5py.File(filename, "r") as infile:
                         if file_nr_attr is not None:
                             obj, attr = file_nr_attr
-                            nr_files = int(infile[obj].attrs[attr].flat[0])
+                            nr_files = int(np.asarray(infile[obj].attrs[attr]).flat[0])
                             file_idx = np.arange(nr_files)
                         elif file_nr_dataset is not None:
-                            nr_files = int(infile[file_nr_dataset][0])
+                            nr_files = int(np.asarray(infile[file_nr_dataset]).flat[0])
                             file_idx = np.arange(nr_files)
                         else:
                             raise Exception("Must specify one of file_nr_attr, file_nr_dataset, file_idx")


### PR DESCRIPTION
When I try and load a file with numpy > 2.4 I get an error.

```
from mpi4py import MPI

comm = MPI.COMM_WORLD
comm_rank = comm.Get_rank()
comm_size = comm.Get_size()

import virgo.mpi.parallel_hdf5 as phdf5

snap_filename = "/cosma8/data/dp004/colibre/Runs/L0025N0188/Thermal/snapshots/colibre_0127/colibre_0127.{file_nr}.hdf5"
file = phdf5.MultiFile(
    snap_filename, file_nr_attr=("Header", "NumFilesPerSnapshot"), comm=comm
)
```
gives
```
Traceback (most recent call last):
  File "/cosma/home/dp004/dc-mcgi1/soap_pato/load.py", line 10, in <module>
    file = phdf5.MultiFile(
           ^^^^^^^^^^^^^^^^
  File "/cosma/home/dp004/dc-mcgi1/soap_pato/VirgoDC/python/virgo/mpi/parallel_hdf5.py", line 338, in __init__
    nr_files = int(infile[obj].attrs[attr])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

This changes updates the reading of attributes.