### PR TITLE
Add option to use existing group in MultiFile.write

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -465,7 +465,7 @@ distributed between files in the same way as an input file set.
 
 ```
 virgo.mpi.parallel_hdf5.MultiFile.write(self, data, elements_per_file,
-    filenames, mode, group=None, attrs=None)
+    filenames, mode, group=None, attrs=None, create_dataset=True)
 ```
 This writes the supplied distributed arrays to a set of output files with the
 specified number of elements per file. The number of output files is the same
@@ -482,6 +482,9 @@ as in the input file set used to initialize the class.
   * `group` - the name of the HDF5 group to write the datasets to
   * `attrs` - a dict containing attributes to add to the datasets, of the form
     `attrs[dataset_name] = (attribute_name, attribute_value)`
+  * `create_dataset` - a bool specifying whether the dataset should be created,
+    if `False` it is assumed that a dataset of the appropriate shape and type
+    already exists (default is `True`)
 
 The get_elements_per_file() method can be used to get the value of
 elements_per_file needed to write output partitioned in the same way as some

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -683,7 +683,7 @@ class MultiFile:
         return elements_per_file
 
     def _write_independent(self, data, elements_per_file, all_filenames, mode, group=None, attrs=None,
-                           dcpl=None, gzip=None, shuffle=False, chunk=None):
+                           dcpl=None, gzip=None, shuffle=False, chunk=None, create_dataset=True):
         """
         Write arrays to multiple files, assuming at least one file per MPI rank.
         """
@@ -712,12 +712,15 @@ class MultiFile:
                 # Write the data
                 length = elements_per_file[self.all_file_indexes[i]]
                 for name in data:
-                    shape = tuple((length,)+data[name].shape[1:])
-                    dcpl_compressed = compress_dcpl(dcpl, shape, gzip, shuffle, chunk)
-                    dspace_id = h5py.h5s.create_simple(shape)
-                    dtype_id = h5py.h5t.py_create(data[name].dtype)
-                    dataset_id = h5py.h5d.create(loc.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
-                    dataset = h5py.Dataset(dataset_id)
+                    if create_dataset:
+                        shape = tuple((length,)+data[name].shape[1:])
+                        dcpl_compressed = compress_dcpl(dcpl, shape, gzip, shuffle, chunk)
+                        dspace_id = h5py.h5s.create_simple(shape)
+                        dtype_id = h5py.h5t.py_create(data[name].dtype)
+                        dataset_id = h5py.h5d.create(loc.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
+                        dataset = h5py.Dataset(dataset_id)
+                    else:
+                        dataset = loc[name]
                     dataset[...] = data[name][offset:offset+length,...]
                     if attrs is not None and name in attrs:
                         for attr_name, attr_val in attrs[name].items():
@@ -726,7 +729,7 @@ class MultiFile:
                 offset += length
 
     def _write_collective(self, data, elements_per_file, all_filenames, mode, group=None, attrs=None,
-                          dcpl=None, gzip=None, shuffle=False, chunk=None):
+                          dcpl=None, gzip=None, shuffle=False, chunk=None, create_dataset=True):
         """
         Write arrays to multiple files in collective mode.
         """
@@ -751,7 +754,8 @@ class MultiFile:
             assert length == data[name].shape[0]
             length_tot = comm.allreduce(length)
             dataset = collective_write(loc, name, data[name], comm, dcpl=dcpl,
-                                       gzip=gzip, shuffle=shuffle, chunk=chunk)
+                                       gzip=gzip, shuffle=shuffle, chunk=chunk,
+                                       create_dataset=create_dataset)
             if attrs is not None and name in attrs:
                 for attr_name, attr_val in attrs[name].items():
                     dataset.attrs[attr_name] = attr_val
@@ -760,7 +764,7 @@ class MultiFile:
         comm.Free()
 
     def write(self, data, elements_per_file, filenames, mode, group=None, attrs=None, dcpl=None,
-              gzip=None, shuffle=False, chunk=None):
+              gzip=None, shuffle=False, chunk=None, create_dataset=True):
         """
         Write out the supplied datasets with the same layout as the
         input. Use mode parameter to choose whether to create new
@@ -783,9 +787,9 @@ class MultiFile:
         if self.collective:
             # Collective mode
             self._write_collective(data, elements_per_file, all_filenames, mode, group, attrs, dcpl,
-                                   gzip, shuffle, chunk)
+                                   gzip, shuffle, chunk, create_dataset)
         else:
             # Independent mode
             self._write_independent(data, elements_per_file, all_filenames, mode, group, attrs, dcpl,
-                                    gzip, shuffle, chunk)
+                                    gzip, shuffle, chunk, create_dataset)
             


### PR DESCRIPTION
This is to test Kyle's changes from #11, because I couldn't see how to make the test workflow run there.