### PR TITLE
Support collective read/write without parallel HDF5

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,3 +40,35 @@ jobs:
     - name: Eight process test
       run: |
         mpirun --oversubscribe -np 8 python3 -m pytest --with-mpi
+
+  build_serial_hdf5:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y -q openmpi-bin libopenmpi-dev
+        python -m pip install --upgrade pip
+        pip install h5py mpi4py
+        pip install pytest pytest-mpi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Verify h5py has no parallel support
+      run: |
+        python3 -c "import h5py; assert not h5py.get_config().mpi, 'h5py was built with parallel support'"
+    - name: Single process test
+      run: |
+        mpirun --oversubscribe -np 1 python3 -m pytest --with-mpi
+    - name: Two process test
+      run: |
+        mpirun --oversubscribe -np 2 python3 -m pytest --with-mpi
+    - name: Three process test
+      run: |
+        mpirun --oversubscribe -np 3 python3 -m pytest --with-mpi
+    - name: Four process test
+      run: |
+        mpirun --oversubscribe -np 4 python3 -m pytest --with-mpi
+    - name: Eight process test
+      run: |
+        mpirun --oversubscribe -np 8 python3 -m pytest --with-mpi

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-mpi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Verify SERIAL_HDF5 is false
+      run: |
+        PYTHONPATH=python python3 -c "import virgo.mpi.parallel_hdf5 as phdf5; assert not phdf5.SERIAL_HDF5, 'SERIAL_HDF5 is true, but parallel HDF5 is installed'"
     - name: Single process test
       run: |
         mpirun --oversubscribe -np 1 python3 -m pytest --with-mpi

--- a/python/README.md
+++ b/python/README.md
@@ -20,8 +20,8 @@ loading environment modules) and run
 python -m pip install mpi4py
 ```
 
-To install h5py, if the right mpicc is in your $PATH and HDF5 is installed at
-$HDF5_HOME:
+To install h5py with parallel support, ensure the right mpicc is in your
+$PATH and HDF5 is installed at $HDF5_HOME:
 ```
 export CC="mpicc"
 export HDF5_MPI="ON"
@@ -33,6 +33,13 @@ Running the tests requires pytest-mpi:
 ```
 pip install pytest-mpi
 ```
+
+If h5py is installed without parallel support, virgo.mpi.parallel_hdf5 falls
+back to gathering data onto a single MPI rank and doing serial HDF5 I/O
+instead of a genuine parallel collective read/write. This fallback is
+intended only as a convenience for testing on systems where a parallel HDF5
+build isn't available. For any real usage, install h5py with parallel support
+as described above.
 
 The module can then be installed using pip:
 ```
@@ -334,6 +341,10 @@ The module virgo.mpi.parallel_hdf5 contains functions for reading and writing
 distributed arrays stored in sets of HDF5 files, using MPI collective I/O
 where possible. These can be useful for reading simulation snapshots and halo
 finder output.
+
+If `virgo.mpi.parallel_hdf5.SERIAL_HDF5` is True, h5py was built without
+parallel support, and `MultiFile` transparently falls back to serial I/O on
+a single rank. This fallback should be avoided for production runs.
 
 ### Collective HDF5 Read
 

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 import collections
+import sys
 
 import numpy as np
 import h5py
@@ -9,6 +10,10 @@ import virgo.mpi.util
 # Default maximum size of I/O operations in bytes.
 # This is to avoid MPI issues with buffers >2GB.
 BUFFER_SIZE=100*1024*1024
+
+# Whether we're running without parallel HDF5. If so, MultiFile falls back to
+# independent I/O when multiple ranks need to share a single file.
+SERIAL_HDF5 = not bool(h5py.get_config().mpi)
 
 
 def substitute_file_nr(format_string, file_nr):
@@ -122,14 +127,15 @@ def collective_read(dataset, comm, buffer_size=None):
     # Determine offsets to read at on each task
     offset_on_task = np.cumsum(num_on_task) - num_on_task
 
-    if ntot < 10*comm_size:
-        # If the dataset is small, read on one rank and broadcast
+    if ntot < 10*comm_size or SERIAL_HDF5:
+        # If the dataset is small, or parallel HDF5 is not available, read on
+        # one rank and send each rank only its own slice
         if comm_rank == 0:
             data = dataset[...]
+            chunks = [data[offset_on_task[i]:offset_on_task[i]+num_on_task[i],...] for i in range(comm_size)]
         else:
-            data = None
-        data = comm.bcast(data)
-        return data[offset_on_task[comm_rank]:offset_on_task[comm_rank]+num_on_task[comm_rank],...]
+            chunks = None
+        return comm.scatter(chunks)
     else:
         # Otherwise do a collective read
         # Reading >2GB fails, so we may need to chunk the read.
@@ -169,7 +175,7 @@ def collective_write(group, name, data, comm, buffer_size=None, create_dataset=T
     """
     Do a parallel collective write of a HDF5 dataset by concatenating
     contributions from MPI ranks along the first axis.
-    
+
     File must have been opened in MPI mode.
     """
 
@@ -368,6 +374,11 @@ class MultiFile:
         else:
             # More ranks than files, so use collective reading and assign ranks to files.
             self.collective = True
+            if SERIAL_HDF5 and comm_rank == 0:
+                print("WARNING: more MPI ranks than files, but parallel HDF5 is not "
+                      "available. Falling back to non-parallel I/O, which will be "
+                      "slower and less memory efficient. Install a parallel HDF5 "
+                      "build for better performance.", file=sys.stderr, flush=True)
             num_ranks_on_file = assign_files(comm_size, num_files)
             first_rank_on_file = np.cumsum(num_ranks_on_file) - num_ranks_on_file
             # Find which file this rank is assigned to
@@ -492,9 +503,13 @@ class MultiFile:
         else:
             file_nr = None
 
-        # Open the file
+        # Open the file. Without parallel HDF5, each rank sharing this file
+        # opens its own independent, serial handle instead of a shared one.
         filename = self.filenames[self.collective_file_nr]
-        infile = h5py.File(filename, "r", driver="mpio", comm=comm)
+        if SERIAL_HDF5:
+            infile = h5py.File(filename, "r")
+        else:
+            infile = h5py.File(filename, "r", driver="mpio", comm=comm)
 
         # Find HDF5 group to read from
         if group is None:
@@ -634,32 +649,41 @@ class MultiFile:
 
         # Avoid initializing HDF5 (and therefore MPI) until necessary
         import h5py
-        
+
         elements_per_file = {}
         if self.collective:
-            # Collective I/O: groups of ranks read a file each
+            # Collective I/O: groups of ranks read a file each. Only the
+            # total number of elements is needed, so rank 0 of the group
+            # alone opens the file (no need for a parallel HDF5 driver) and
+            # broadcasts it to the rest of the group.
             comm = self.comm.Split(self.collective_file_nr, self.rank_in_file)
+            comm_rank = comm.Get_rank()
+            comm_size = comm.Get_size()
             filename = self.filenames[self.collective_file_nr]
-            infile = h5py.File(filename, "r", driver="mpio", comm=comm)            
-            # Determine group to read from
-            if group is None:
-                loc = infile
-            elif group in infile:
-                loc = infile[group]
+            if comm_rank == 0:
+                with h5py.File(filename, "r") as infile:
+                    # Determine group to read from
+                    if group is None:
+                        loc = infile
+                    elif group in infile:
+                        loc = infile[group]
+                    else:
+                        loc = None
+                    if loc is not None and name in loc:
+                        ntot = loc[name].shape[0]
+                    else:
+                        ntot = None
             else:
-                loc = None
-            if loc is not None and name in loc:
-                ntot = loc[name].shape[0]
-                comm_size = comm.Get_size()
-                comm_rank = comm.Get_rank()
+                ntot = None
+            ntot = comm.bcast(ntot)
+            if ntot is None:
+                elements_per_file[self.all_file_indexes[self.collective_file_nr]] = 0
+            else:
                 num_on_task = np.zeros(comm_size, dtype=int)
                 num_on_task[:] = ntot // comm_size
                 num_on_task[0:ntot % comm_size] += 1
                 assert sum(num_on_task) == ntot
                 elements_per_file[self.all_file_indexes[self.collective_file_nr]] = num_on_task[comm_rank]
-            else:
-                elements_per_file[self.all_file_indexes[self.collective_file_nr]] = 0
-            infile.close()
             comm.Free()
         else:
             # Independent I/O: different ranks read different files
@@ -702,7 +726,7 @@ class MultiFile:
         for i in range(first, first+num):
             filename = all_filenames[i]
             with h5py.File(filename, mode) as outfile:
-                
+
                 # Ensure the group exists
                 if group is not None:
                     loc = outfile.require_group(group)
@@ -738,8 +762,43 @@ class MultiFile:
         import h5py
         comm = self.comm.Split(self.collective_file_nr, self.rank_in_file)
 
-        # Open the file
         filename = all_filenames[self.collective_file_nr]
+
+        if SERIAL_HDF5:
+            # No parallel HDF5 available: gather each dataset onto rank 0 of
+            # the group of ranks sharing this file, then write it there with
+            # a plain, serial file open.
+            import virgo.mpi.gather_array as ga
+            length = elements_per_file[self.all_file_indexes[self.collective_file_nr]]
+            for name in data:
+                assert length == data[name].shape[0]
+            gathered_data = {name : ga.gather_array(data[name], root=0, comm=comm) for name in data}
+            if comm.Get_rank() == 0:
+                if dcpl is None:
+                    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+                with h5py.File(filename, mode) as outfile:
+                    if group is not None:
+                        loc = outfile.require_group(group)
+                    else:
+                        loc = outfile
+                    for name in gathered_data:
+                        if create_dataset:
+                            shape = gathered_data[name].shape
+                            dcpl_compressed = compress_dcpl(dcpl, shape, gzip, shuffle, chunk)
+                            dspace_id = h5py.h5s.create_simple(shape)
+                            dtype_id = h5py.h5t.py_create(gathered_data[name].dtype)
+                            dataset_id = h5py.h5d.create(loc.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
+                            dataset = h5py.Dataset(dataset_id)
+                        else:
+                            dataset = loc[name]
+                        dataset[...] = gathered_data[name]
+                        if attrs is not None and name in attrs:
+                            for attr_name, attr_val in attrs[name].items():
+                                dataset.attrs[attr_name] = attr_val
+            comm.Free()
+            return
+
+        # Open the file
         outfile = h5py.File(filename, mode, driver="mpio", comm=comm)
 
         # Ensure the group exists
@@ -747,7 +806,7 @@ class MultiFile:
             loc = outfile.require_group(group)
         else:
             loc = outfile
-        
+
         # Write the data
         for name in data:
             length = elements_per_file[self.all_file_indexes[self.collective_file_nr]]
@@ -759,7 +818,7 @@ class MultiFile:
             if attrs is not None and name in attrs:
                 for attr_name, attr_val in attrs[name].items():
                     dataset.attrs[attr_name] = attr_val
-         
+
         outfile.close()
         comm.Free()
 

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -723,22 +723,29 @@ class MultiFile:
             comm_size = comm.Get_size()
             filename = self.filenames[self.collective_file_nr]
             if comm_rank == 0:
-                # Read the number of elements on rank 0 and broadcast
-                with h5py.File(filename, "r") as infile:
-                    # Determine group to read from
-                    if group is None:
-                        loc = infile
-                    elif group in infile:
-                        loc = infile[group]
-                    else:
-                        loc = None
-                    if loc is not None and name in loc:
-                        ntot = loc[name].shape[0]
-                    else:
-                        ntot = None
+                # Read the number of elements on rank 0 and broadcast.
+                # Any exception is turned into a value and broadcast too.
+                try:
+                    with h5py.File(filename, "r") as infile:
+                        # Determine group to read from
+                        if group is None:
+                            loc = infile
+                        elif group in infile:
+                            loc = infile[group]
+                        else:
+                            loc = None
+                        if loc is not None and name in loc:
+                            ntot = loc[name].shape[0]
+                        else:
+                            ntot = None
+                    result = (None, ntot)
+                except Exception as e:
+                    result = (str(e), None)
             else:
-                ntot = None
-            ntot = comm.bcast(ntot)
+                result = None
+            error, ntot = comm.bcast(result)
+            if error is not None:
+                raise RuntimeError(f"Rank 0 failed to read from {filename}: {error}")
             if ntot is None:
                 elements_per_file[self.all_file_indexes[self.collective_file_nr]] = 0
             else:
@@ -831,12 +838,26 @@ class MultiFile:
             # No parallel HDF5 available: gather each dataset onto rank 0 of
             # the group of ranks sharing this file, then write it there with
             # a plain, serial file open.
+            # Open the file (and group) on rank 0 only.
             if comm.Get_rank() == 0:
-                outfile = h5py.File(filename, mode)
-                loc = outfile.require_group(group) if group is not None else outfile
+                try:
+                    outfile = h5py.File(filename, mode)
+                    loc = outfile.require_group(group) if group is not None else outfile
+                    error = None
+                except Exception as e:
+                    outfile = None
+                    loc = None
+                    error = str(e)
             else:
                 outfile = None
                 loc = None
+                error = None
+            error = comm.bcast(error)
+            if error is not None:
+                if outfile is not None:
+                    outfile.close()
+                comm.Free()
+                raise RuntimeError(f"Rank 0 failed to open {filename}: {error}")
             for name in data:
                 length = elements_per_file[self.all_file_indexes[self.collective_file_nr]]
                 assert length == data[name].shape[0]

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -128,13 +128,15 @@ def collective_read(dataset, comm, buffer_size=None):
 
     if ntot < 10*comm_size or SERIAL_HDF5:
         # If the dataset is small, or parallel HDF5 is not available, read on
-        # one rank and send each rank only its own slice
+        # one rank and repartition so each rank gets its own slice.
+        # Uses repartition() rather than scatter() because scatter() is not
+        # safe for messages >2GB.
+        import virgo.mpi.parallel_sort as psort
         if comm_rank == 0:
             data = dataset[...]
-            chunks = [data[offset_on_task[i]:offset_on_task[i]+num_on_task[i],...] for i in range(comm_size)]
         else:
-            chunks = None
-        return comm.scatter(chunks)
+            data = np.empty((0,)+dataset.shape[1:], dtype=dataset.dtype)
+        return psort.repartition(data, num_on_task, comm=comm)
     else:
         # Otherwise do a collective read
         # Reading >2GB fails, so we may need to chunk the read.
@@ -169,6 +171,63 @@ def collective_read(dataset, comm, buffer_size=None):
     return data
 
 
+def _collective_write_metadata(data, comm):
+    """
+    Shared setup for collective_write() and serial_collective_write():
+    ensure the input is contiguous, count how many elements each rank is
+    contributing to the write, and check that shape/dtype are consistent
+    across ranks.
+
+    Returns (data, num_on_task, ntot, shape, dtype), where shape/dtype are
+    the values agreed by all ranks (excluding the first axis of shape).
+    """
+
+    # Ensure input is a contiguous numpy array
+    data = np.ascontiguousarray(data)
+
+    # Determine how many elements each rank is contributing
+    num_on_task = np.asarray(comm.allgather(data.shape[0]))
+    ntot = np.sum(num_on_task)
+
+    # Need to have all dimensions but the first the same between ranks
+    shape_local = tuple(data.shape[1:])
+    shape = tuple(comm.bcast(shape_local))
+    if shape_local != shape:
+        raise ValueError("Inconsistent data shapes in collective write!")
+
+    # Need to have the same data type on all ranks
+    dtype_local = data.dtype
+    dtype = comm.bcast(dtype_local)
+    if dtype_local != dtype:
+        raise ValueError("Inconsistent data types in collective write!")
+
+    return data, num_on_task, ntot, shape, dtype
+
+
+def _create_or_open_dataset(loc, name, full_shape, dtype, create_dataset, dcpl, gzip, shuffle, chunk):
+    """
+    Shared dataset creation for collective_write() and
+    serial_collective_write(): create a new dataset with the requested
+    shape/compression, or fetch the existing one if create_dataset=False.
+    """
+
+    import h5py
+
+    if not create_dataset:
+        return loc[name]
+
+    if dcpl is None:
+        dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+    else:
+        dcpl = dcpl.copy()
+
+    dcpl_compressed = compress_dcpl(dcpl, full_shape, gzip, shuffle, chunk)
+    dspace_id = h5py.h5s.create_simple(tuple(full_shape))
+    dtype_id = h5py.h5t.py_create(dtype)
+    dataset_id = h5py.h5d.create(loc.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
+    return h5py.Dataset(dataset_id)
+
+
 def collective_write(group, name, data, comm, buffer_size=None, create_dataset=True,
                      dcpl=None, gzip=None, shuffle=False, chunk=None):
     """
@@ -182,54 +241,22 @@ def collective_write(group, name, data, comm, buffer_size=None, create_dataset=T
         buffer_size = BUFFER_SIZE
 
     import h5py
-    from mpi4py import MPI
-
-    # Get (or update) dataset creation property list
-    if create_dataset:
-        if dcpl is None:
-            dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
-        else:
-            dcpl = dcpl.copy()
-
-    # Ensure input is a contiguous numpy array
-    data = np.ascontiguousarray(data)
 
     # Find communicator file was opened with
     #comm, info = group.file.id.get_access_plist().get_fapl_mpio()
     comm_rank = comm.Get_rank()
-    comm_size = comm.Get_size()
 
-    # Determine how many elements to write on each task
-    num_on_task = np.asarray(comm.allgather(data.shape[0]))
-    ntot = np.sum(num_on_task)
+    data, num_on_task, ntot, shape, dtype = _collective_write_metadata(data, comm)
 
     # Determine offsets at which to write data from each task
     offset_on_task = np.cumsum(num_on_task) - num_on_task
 
-    # Need to have all dimensions but the first the same between ranks
-    shape_local = tuple(data.shape[1:])
-    shape_rank0 = tuple(comm.bcast(shape_local))
-    if shape_local != shape_rank0:
-        raise ValueError("Inconsistent data shapes in collective_write()!")
-
-    # Need to have the same data type on all ranks
-    dtype_local = data.dtype
-    dtype_rank0 = comm.bcast(dtype_local)
-    if dtype_local != dtype_rank0:
-        raise ValueError("Inconsistent data types in collective_write()!")
-
     # Find the full shape of the new dataset
-    full_shape = [ntot,] + list(shape_local)
+    full_shape = (ntot,) + shape
 
     # Create the dataset if necessary
-    if create_dataset:
-        dspace_id = h5py.h5s.create_simple(tuple(full_shape))
-        dtype_id = h5py.h5t.py_create(data.dtype)
-        dcpl_compressed = compress_dcpl(dcpl, full_shape, gzip, shuffle, chunk)
-        dataset_id = h5py.h5d.create(group.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
-        dataset = h5py.Dataset(dataset_id)
-    else:
-        dataset = group[name]
+    dataset = _create_or_open_dataset(group, name, full_shape, dtype, create_dataset,
+                                      dcpl, gzip, shuffle, chunk)
 
     # Determine slice to write
     file_offset   = offset_on_task[comm_rank]
@@ -280,6 +307,46 @@ def collective_write(group, name, data, comm, buffer_size=None, create_dataset=T
         file_offset   += nr_to_write
         memory_offset += nr_to_write
         nr_left       -= nr_to_write
+
+    return dataset
+
+
+def serial_collective_write(group, name, data, comm, create_dataset=True,
+                            dcpl=None, gzip=None, shuffle=False, chunk=None):
+    """
+    Serial equivalent of collective_write(): gather the contributions from
+    all MPI ranks onto rank 0 and write them there using a plain,
+    non-parallel HDF5 file handle.
+
+    group must be open (or None) on rank 0 only - it is not accessed on
+    other ranks. Returns the dataset on rank 0 and None elsewhere.
+
+    Ranks other than 0 may return before rank 0 has finished writing, so
+    callers must comm.barrier() before relying on the write being complete
+    (e.g. before closing the file or reading it back).
+    """
+
+    import virgo.mpi.parallel_sort as psort
+
+    comm_rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+
+    data, num_on_task, ntot, shape, dtype = _collective_write_metadata(data, comm)
+
+    # Gather all the data onto rank 0. Uses repartition() rather than
+    # gather_array()/Gatherv() because those are not safe for messages >2GB.
+    ndesired = np.zeros(comm_size, dtype=int)
+    ndesired[0] = ntot
+    gathered_data = psort.repartition(data, ndesired, comm=comm)
+
+    if comm_rank != 0:
+        return None
+
+    # Create the dataset if necessary
+    full_shape = (ntot,) + shape
+    dataset = _create_or_open_dataset(group, name, full_shape, dtype, create_dataset,
+                                      dcpl, gzip, shuffle, chunk)
+    dataset[...] = gathered_data
 
     return dataset
 
@@ -764,33 +831,27 @@ class MultiFile:
             # No parallel HDF5 available: gather each dataset onto rank 0 of
             # the group of ranks sharing this file, then write it there with
             # a plain, serial file open.
-            import virgo.mpi.gather_array as ga
-            length = elements_per_file[self.all_file_indexes[self.collective_file_nr]]
-            for name in data:
-                assert length == data[name].shape[0]
-            gathered_data = {name : ga.gather_array(data[name], root=0, comm=comm) for name in data}
             if comm.Get_rank() == 0:
-                if dcpl is None:
-                    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
-                with h5py.File(filename, mode) as outfile:
-                    if group is not None:
-                        loc = outfile.require_group(group)
-                    else:
-                        loc = outfile
-                    for name in gathered_data:
-                        if create_dataset:
-                            shape = gathered_data[name].shape
-                            dcpl_compressed = compress_dcpl(dcpl, shape, gzip, shuffle, chunk)
-                            dspace_id = h5py.h5s.create_simple(shape)
-                            dtype_id = h5py.h5t.py_create(gathered_data[name].dtype)
-                            dataset_id = h5py.h5d.create(loc.id, name.encode(), dtype_id, dspace_id, dcpl=dcpl_compressed)
-                            dataset = h5py.Dataset(dataset_id)
-                        else:
-                            dataset = loc[name]
-                        dataset[...] = gathered_data[name]
-                        if attrs is not None and name in attrs:
-                            for attr_name, attr_val in attrs[name].items():
-                                dataset.attrs[attr_name] = attr_val
+                outfile = h5py.File(filename, mode)
+                loc = outfile.require_group(group) if group is not None else outfile
+            else:
+                outfile = None
+                loc = None
+            for name in data:
+                length = elements_per_file[self.all_file_indexes[self.collective_file_nr]]
+                assert length == data[name].shape[0]
+                dataset = serial_collective_write(loc, name, data[name], comm, dcpl=dcpl,
+                                                  gzip=gzip, shuffle=shuffle, chunk=chunk,
+                                                  create_dataset=create_dataset)
+                if dataset is not None and attrs is not None and name in attrs:
+                    for attr_name, attr_val in attrs[name].items():
+                        dataset.attrs[attr_name] = attr_val
+            if outfile is not None:
+                outfile.close()
+            # Ranks whose repartition() exchange with rank 0 completed early
+            # could otherwise race ahead before rank 0 has written and
+            # closed the file.
+            comm.barrier()
             comm.Free()
             return
 

--- a/python/virgo/mpi/parallel_hdf5.py
+++ b/python/virgo/mpi/parallel_hdf5.py
@@ -11,8 +11,7 @@ import virgo.mpi.util
 # This is to avoid MPI issues with buffers >2GB.
 BUFFER_SIZE=100*1024*1024
 
-# Whether we're running without parallel HDF5. If so, MultiFile falls back to
-# independent I/O when multiple ranks need to share a single file.
+# Whether we're running without parallel HDF5.
 SERIAL_HDF5 = not bool(h5py.get_config().mpi)
 
 
@@ -503,8 +502,7 @@ class MultiFile:
         else:
             file_nr = None
 
-        # Open the file. Without parallel HDF5, each rank sharing this file
-        # opens its own independent, serial handle instead of a shared one.
+        # Open the file
         filename = self.filenames[self.collective_file_nr]
         if SERIAL_HDF5:
             infile = h5py.File(filename, "r")
@@ -652,15 +650,13 @@ class MultiFile:
 
         elements_per_file = {}
         if self.collective:
-            # Collective I/O: groups of ranks read a file each. Only the
-            # total number of elements is needed, so rank 0 of the group
-            # alone opens the file (no need for a parallel HDF5 driver) and
-            # broadcasts it to the rest of the group.
+            # Collective I/O: groups of ranks read a file each
             comm = self.comm.Split(self.collective_file_nr, self.rank_in_file)
             comm_rank = comm.Get_rank()
             comm_size = comm.Get_size()
             filename = self.filenames[self.collective_file_nr]
             if comm_rank == 0:
+                # Read the number of elements on rank 0 and broadcast
                 with h5py.File(filename, "r") as infile:
                     # Determine group to read from
                     if group is None:

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -13,6 +13,17 @@ comm_rank = comm.Get_rank()
 np.random.seed(comm_rank)
 
 
+@pytest.fixture(params=[False, True], ids=["parallel_hdf5", "serial_hdf5"])
+def serial_hdf5(request, monkeypatch):
+    """
+    Runs a test twice: once against whatever parallel HDF5 support is
+    actually installed, and once with phdf5.SERIAL_HDF5 forced True to
+    exercise the non-parallel fallback regardless of what's installed.
+    """
+    monkeypatch.setattr(phdf5, "SERIAL_HDF5", request.param)
+    return request.param
+
+
 def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     """
     Write out a dataset in serial mode, read it back in collective mode
@@ -46,8 +57,12 @@ def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     comm.barrier()
 
     # Read back in the test data
-    with h5py.File(filepath, "r", driver="mpio", comm=comm) as infile:
-        arr_coll = phdf5.collective_read(infile["data"], comm, buffer_size)
+    if phdf5.SERIAL_HDF5:
+        with h5py.File(filepath, "r") as infile:
+            arr_coll = phdf5.collective_read(infile["data"], comm, buffer_size)
+    else:
+        with h5py.File(filepath, "r", driver="mpio", comm=comm) as infile:
+            arr_coll = phdf5.collective_read(infile["data"], comm, buffer_size)
 
     # Check the result on rank 0
     arr_coll = comm.gather(arr_coll)
@@ -60,14 +75,14 @@ def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     assert all_equal, "Collective read returned incorrect data"
 
 @pytest.mark.mpi
-def test_collective_read_empty(tmp_path):
+def test_collective_read_empty(tmp_path, serial_hdf5):
     """
     Test collective read of an empty dataset
     """
     do_collective_read(tmp_path, 0)
 
 @pytest.mark.mpi
-def test_collective_read_1d(tmp_path):
+def test_collective_read_1d(tmp_path, serial_hdf5):
     """
     Test collective reads of various size 1D datasets
     """
@@ -75,7 +90,7 @@ def test_collective_read_1d(tmp_path):
         do_collective_read(tmp_path, max_local_size)
 
 @pytest.mark.mpi
-def test_collective_read_small_chunks_1d(tmp_path):
+def test_collective_read_small_chunks_1d(tmp_path, serial_hdf5):
     """
     Test collective reads of various size 1D datasets
 
@@ -85,7 +100,7 @@ def test_collective_read_small_chunks_1d(tmp_path):
         do_collective_read(tmp_path, max_local_size, buffer_size=256)
 
 @pytest.mark.mpi
-def test_collective_read_2d(tmp_path):
+def test_collective_read_2d(tmp_path, serial_hdf5):
     """
     Test collective reads of various size 2D datasets
     """
@@ -93,7 +108,7 @@ def test_collective_read_2d(tmp_path):
         do_collective_read(tmp_path, (max_local_size, 3))
 
 @pytest.mark.mpi
-def test_collective_read_small_chunks_2d(tmp_path):
+def test_collective_read_small_chunks_2d(tmp_path, serial_hdf5):
     """
     Test collective reads of various size 2D datasets
 
@@ -365,12 +380,12 @@ def do_multi_file_test(tmp_path, basename, nr_files, elements_per_file, group=No
     read_multi_file_output(tmp_path, basename, group=group, attrs=attrs)
 
 @pytest.mark.mpi
-def test_multi_file_single_file(tmp_path):
+def test_multi_file_single_file(tmp_path, serial_hdf5):
     for n in (0, 1, 10, 100, 1000, 10000):
         do_multi_file_test(tmp_path, basename="single_file", nr_files=1, elements_per_file=n)
 
 @pytest.mark.mpi
-def test_multi_file_single_file_group(tmp_path):
+def test_multi_file_single_file_group(tmp_path, serial_hdf5):
     for n in (0, 1, 10, 100, 1000, 10000):
         do_multi_file_test(tmp_path, basename="single_file_group", nr_files=1, elements_per_file=n,
                            group="group")
@@ -408,7 +423,7 @@ def test_multi_file_more_files_than_ranks_group_missing(tmp_path):
                            group="group", have_missing=True)
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files(tmp_path):
+def test_multi_file_more_ranks_than_files(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -422,7 +437,7 @@ def test_multi_file_more_ranks_than_files(tmp_path):
         do_multi_file_test(tmp_path, basename="more_ranks", nr_files=nr_files, elements_per_file=n)
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files_group(tmp_path):
+def test_multi_file_more_ranks_than_files_group(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -437,7 +452,7 @@ def test_multi_file_more_ranks_than_files_group(tmp_path):
                            group="group")
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files_group_missing(tmp_path):
+def test_multi_file_more_ranks_than_files_group_missing(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -489,7 +504,7 @@ def test_inconsistent_dtype_independent(tmp_path):
                                elements_per_file=n, group="group", inconsistent_dtype=True)
 
 @pytest.mark.mpi
-def test_inconsistent_dtype_collective(tmp_path):
+def test_inconsistent_dtype_collective(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -604,7 +619,7 @@ def multi_file_round_trip_all_methods(tmp_path, nr_files, elements_per_file, bas
                                   have_missing, group, filename_method=filename_method, compression=compression)
 
 @pytest.mark.mpi
-def test_round_trip_single_file(tmp_path):
+def test_round_trip_single_file(tmp_path, serial_hdf5):
     multi_file_round_trip_all_methods(tmp_path, nr_files=1, elements_per_file=10000,
                           basename="round_trip_single_file")
 
@@ -619,7 +634,7 @@ def test_round_trip_file_per_rank(tmp_path):
                                       basename="round_trip_file_per_rank")
 
 @pytest.mark.mpi
-def test_round_trip_few_files(tmp_path):
+def test_round_trip_few_files(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -630,7 +645,7 @@ def test_round_trip_few_files(tmp_path):
                                       basename="round_trip_few_files")
 
 @pytest.mark.mpi
-def test_round_trip_few_files_missing(tmp_path):
+def test_round_trip_few_files_missing(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -644,7 +659,7 @@ def test_round_trip_few_files_missing(tmp_path):
                                       basename="round_trip_few_files_missing", have_missing=True)
 
 @pytest.mark.mpi
-def test_round_trip_few_files_missing_group(tmp_path):
+def test_round_trip_few_files_missing_group(tmp_path, serial_hdf5):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -203,6 +203,106 @@ def test_collective_write_small_chunks_2d(tmp_path):
     for max_local_size in (1, 10, 100, 1000, 10000, 100000):
         do_collective_write(tmp_path, (max_local_size,3), buffer_size=256)
 
+
+def do_serial_collective_write(tmp_path, max_local_size, chunk=None):
+    """
+    Write out a dataset with serial_collective_write() (gather onto rank
+    zero, write with a plain, non-parallel HDF5 file handle), then gather
+    on rank zero to check that the contents are correct.
+
+    Repeats test with different compression options. Unlike
+    collective_write(), this does not depend on parallel HDF5, so it is
+    run regardless of the value of phdf5.SERIAL_HDF5.
+    """
+
+    no_compression     = {}
+    gzip_chunk         = {"gzip" : 6, "chunk" : chunk}
+    gzip_shuffle_chunk = {"gzip" : 6, "chunk" : chunk, "shuffle" : True}
+
+    for compression in (no_compression, gzip_chunk, gzip_shuffle_chunk):
+
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        comm_rank = comm.Get_rank()
+        comm_size = comm.Get_size()
+
+        # If max_local_size is an int, make it a single element tuple
+        try:
+            max_local_size = tuple([int(i) for i in max_local_size])
+        except TypeError:
+            max_local_size = (int(max_local_size),)
+
+        # Where to write the test file
+        filepath = tmp_path / f"serial_collective_write_test_{max_local_size}.hdf5"
+        filepath = comm.bcast(filepath)
+
+        # Generate the test data
+        if max_local_size[0] > 0:
+            n_local = np.random.randint(max_local_size[0])
+        else:
+            n_local = 0
+        arr_local = np.random.uniform(low=-1.0e6, high=1.0e6, size=(n_local,)+max_local_size[1:])
+
+        # Write out the data, gathering onto rank zero
+        outfile = h5py.File(filepath, "w") if comm_rank == 0 else None
+        phdf5.serial_collective_write(outfile, "data", arr_local, comm, **compression)
+        if outfile is not None:
+            outfile.close()
+        comm.barrier()
+
+        # Gather data on rank zero and check
+        arr = comm.gather(arr_local)
+        if comm_rank == 0:
+            arr = np.concatenate(arr)
+            with h5py.File(filepath, "r") as infile:
+                arr_check = infile["data"][...]
+            all_equal = np.all(arr==arr_check)
+        else:
+            all_equal = None
+        all_equal = comm.bcast(all_equal)
+
+        assert all_equal, "serial_collective_write() returned incorrect data"
+
+
+@pytest.mark.mpi
+def test_serial_collective_write_empty(tmp_path):
+    """
+    Test serial collective write of an empty dataset
+    """
+    do_serial_collective_write(tmp_path, 0)
+
+@pytest.mark.mpi
+def test_serial_collective_write_1d(tmp_path):
+    """
+    Test serial collective writes of various size 1D datasets
+    """
+    for max_local_size in (1, 10, 100, 1000, 10000, 100000):
+        do_serial_collective_write(tmp_path, max_local_size)
+
+@pytest.mark.mpi
+def test_serial_collective_write_small_chunks_1d(tmp_path):
+    """
+    Test serial collective writes of various size 1D datasets
+    """
+    for max_local_size in (1, 10, 100, 1000, 10000, 100000):
+        do_serial_collective_write(tmp_path, max_local_size, chunk=256)
+
+@pytest.mark.mpi
+def test_serial_collective_write_2d(tmp_path):
+    """
+    Test serial collective writes of various size 2D datasets
+    """
+    for max_local_size in (1, 10, 100, 1000, 10000, 100000):
+        do_serial_collective_write(tmp_path, (max_local_size,3))
+
+@pytest.mark.mpi
+def test_serial_collective_write_small_chunks_2d(tmp_path):
+    """
+    Test serial collective writes of various size 2D datasets
+    """
+    for max_local_size in (1, 10, 100, 1000, 10000, 100000):
+        do_serial_collective_write(tmp_path, (max_local_size,3), chunk=256)
+
 def create_multi_file_output(
         tmp_path,
         basename,

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -16,9 +16,8 @@ np.random.seed(comm_rank)
 @pytest.fixture(params=[False, True], ids=["parallel_hdf5", "serial_hdf5"])
 def serial_hdf5(request, monkeypatch):
     """
-    Runs a test twice: once against whatever parallel HDF5 support is
-    actually installed, and once with phdf5.SERIAL_HDF5 forced True to
-    exercise the non-parallel fallback regardless of what's installed.
+    Runs a test twice: once against with parallel HDF5 and once to
+    exercise the non-parallel fallback.
     """
     monkeypatch.setattr(phdf5, "SERIAL_HDF5", request.param)
     return request.param

--- a/python/virgo/mpi/test_parallel_hdf5.py
+++ b/python/virgo/mpi/test_parallel_hdf5.py
@@ -13,16 +13,6 @@ comm_rank = comm.Get_rank()
 np.random.seed(comm_rank)
 
 
-@pytest.fixture(params=[False, True], ids=["parallel_hdf5", "serial_hdf5"])
-def serial_hdf5(request, monkeypatch):
-    """
-    Runs a test twice: once against with parallel HDF5 and once to
-    exercise the non-parallel fallback.
-    """
-    monkeypatch.setattr(phdf5, "SERIAL_HDF5", request.param)
-    return request.param
-
-
 def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     """
     Write out a dataset in serial mode, read it back in collective mode
@@ -74,14 +64,14 @@ def do_collective_read(tmp_path, max_local_size, buffer_size=None):
     assert all_equal, "Collective read returned incorrect data"
 
 @pytest.mark.mpi
-def test_collective_read_empty(tmp_path, serial_hdf5):
+def test_collective_read_empty(tmp_path):
     """
     Test collective read of an empty dataset
     """
     do_collective_read(tmp_path, 0)
 
 @pytest.mark.mpi
-def test_collective_read_1d(tmp_path, serial_hdf5):
+def test_collective_read_1d(tmp_path):
     """
     Test collective reads of various size 1D datasets
     """
@@ -89,7 +79,7 @@ def test_collective_read_1d(tmp_path, serial_hdf5):
         do_collective_read(tmp_path, max_local_size)
 
 @pytest.mark.mpi
-def test_collective_read_small_chunks_1d(tmp_path, serial_hdf5):
+def test_collective_read_small_chunks_1d(tmp_path):
     """
     Test collective reads of various size 1D datasets
 
@@ -99,7 +89,7 @@ def test_collective_read_small_chunks_1d(tmp_path, serial_hdf5):
         do_collective_read(tmp_path, max_local_size, buffer_size=256)
 
 @pytest.mark.mpi
-def test_collective_read_2d(tmp_path, serial_hdf5):
+def test_collective_read_2d(tmp_path):
     """
     Test collective reads of various size 2D datasets
     """
@@ -107,7 +97,7 @@ def test_collective_read_2d(tmp_path, serial_hdf5):
         do_collective_read(tmp_path, (max_local_size, 3))
 
 @pytest.mark.mpi
-def test_collective_read_small_chunks_2d(tmp_path, serial_hdf5):
+def test_collective_read_small_chunks_2d(tmp_path):
     """
     Test collective reads of various size 2D datasets
 
@@ -123,6 +113,9 @@ def do_collective_write(tmp_path, max_local_size, buffer_size=None):
 
     Repeats test with different compression options.
     """
+
+    if phdf5.SERIAL_HDF5:
+        pytest.skip("collective_write() requires parallel HDF5")
 
     no_compression     = {}
     gzip_chunk         = {"gzip" : 6, "chunk" : buffer_size}
@@ -379,12 +372,12 @@ def do_multi_file_test(tmp_path, basename, nr_files, elements_per_file, group=No
     read_multi_file_output(tmp_path, basename, group=group, attrs=attrs)
 
 @pytest.mark.mpi
-def test_multi_file_single_file(tmp_path, serial_hdf5):
+def test_multi_file_single_file(tmp_path):
     for n in (0, 1, 10, 100, 1000, 10000):
         do_multi_file_test(tmp_path, basename="single_file", nr_files=1, elements_per_file=n)
 
 @pytest.mark.mpi
-def test_multi_file_single_file_group(tmp_path, serial_hdf5):
+def test_multi_file_single_file_group(tmp_path):
     for n in (0, 1, 10, 100, 1000, 10000):
         do_multi_file_test(tmp_path, basename="single_file_group", nr_files=1, elements_per_file=n,
                            group="group")
@@ -422,7 +415,7 @@ def test_multi_file_more_files_than_ranks_group_missing(tmp_path):
                            group="group", have_missing=True)
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files(tmp_path, serial_hdf5):
+def test_multi_file_more_ranks_than_files(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -436,7 +429,7 @@ def test_multi_file_more_ranks_than_files(tmp_path, serial_hdf5):
         do_multi_file_test(tmp_path, basename="more_ranks", nr_files=nr_files, elements_per_file=n)
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files_group(tmp_path, serial_hdf5):
+def test_multi_file_more_ranks_than_files_group(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -451,7 +444,7 @@ def test_multi_file_more_ranks_than_files_group(tmp_path, serial_hdf5):
                            group="group")
 
 @pytest.mark.mpi
-def test_multi_file_more_ranks_than_files_group_missing(tmp_path, serial_hdf5):
+def test_multi_file_more_ranks_than_files_group_missing(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -503,7 +496,7 @@ def test_inconsistent_dtype_independent(tmp_path):
                                elements_per_file=n, group="group", inconsistent_dtype=True)
 
 @pytest.mark.mpi
-def test_inconsistent_dtype_collective(tmp_path, serial_hdf5):
+def test_inconsistent_dtype_collective(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -618,7 +611,7 @@ def multi_file_round_trip_all_methods(tmp_path, nr_files, elements_per_file, bas
                                   have_missing, group, filename_method=filename_method, compression=compression)
 
 @pytest.mark.mpi
-def test_round_trip_single_file(tmp_path, serial_hdf5):
+def test_round_trip_single_file(tmp_path):
     multi_file_round_trip_all_methods(tmp_path, nr_files=1, elements_per_file=10000,
                           basename="round_trip_single_file")
 
@@ -633,7 +626,7 @@ def test_round_trip_file_per_rank(tmp_path):
                                       basename="round_trip_file_per_rank")
 
 @pytest.mark.mpi
-def test_round_trip_few_files(tmp_path, serial_hdf5):
+def test_round_trip_few_files(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -644,7 +637,7 @@ def test_round_trip_few_files(tmp_path, serial_hdf5):
                                       basename="round_trip_few_files")
 
 @pytest.mark.mpi
-def test_round_trip_few_files_missing(tmp_path, serial_hdf5):
+def test_round_trip_few_files_missing(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -658,7 +651,7 @@ def test_round_trip_few_files_missing(tmp_path, serial_hdf5):
                                       basename="round_trip_few_files_missing", have_missing=True)
 
 @pytest.mark.mpi
-def test_round_trip_few_files_missing_group(tmp_path, serial_hdf5):
+def test_round_trip_few_files_missing_group(tmp_path):
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD


### PR DESCRIPTION
A few people have tried to run SOAP on small boxes, but they don't have h5py built against a parallel version of HDF5. If they set the number of ranks to be less than or equal to the number of files then `MultiFile` will run in independent mode without issues. However, using more ranks than files we end up in collective mode, which requires parallel HDF5. These changes allow collective mode to still run (and give the same results) even without parallel HDF5.

Summary
- Check if we have a parallel version of h5py. Output a warning if someone uses `MultiFile` in collective mode without it.
- `get_elements_per_file` opened the file with the mpio driver to read the number of particles. I've replaced that with a rank 0 read and broadcast.
- `collective_read` already did a serial read and broadcast for very small datasets. Now also do this if parallel HDF5 is unavailable.
- To mirror the behaviour of `collective_write` I've added a gather + serial write. I should probably move this to a separate function (`serial_collective_write`)?

The alternative would be to fall back on independent mode, but then many ranks could end up with zero particles. I can implement that if it's preferred